### PR TITLE
Add support for generating redline diffs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
-FROM pandoc/latex:2.9.2.1
+FROM pandoc/latex:2.11.2
 
 # Install the necessary LaTeX packages
 RUN tlmgr install \
   crimsonpro \
+  # Work around https://bugs.archlinux.org/task/67856 - needed by xecjk
+  ctex \
   draftwatermark \
   enumitem \
   everypage \
   fancyhdr \
+  latexdiff \
   parskip \
   sourcecodepro \
   sourcesanspro \

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Groups to automatically produce Draft and Final Guidelines.
 
 ## Inputs
 
-### `markdown-file`
+### `markdown_file`
 
 **Required** The name of the Markdown file to convert. This should be relative
 to [`GITHUB_WORKSPACE`](https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables).
@@ -15,9 +15,24 @@ In general, running [`actions/checkout`](https://github.com/actions/checkout)
 for the CWG repository is a necessary step before invoking this action, and
 allows just passing the filename relative to the current repository.
 
+### `diff_file`
+
+Optional: The path, relative to
+[`GITHUB_WORKSPACE`](https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables),
+that contains the previous "version" of `markdown_file`.
+
+For example, on a `push` event, this would be the
+[`before`](https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/webhook-events-and-payloads#push)
+SHA-1's file (e.g. using [`actions/checkout`](https://github.com/actions/checkout)
+with a `ref` of `${{ github.event.push.before }}` and a custom `path`).
+
+This is fairly experimental and prone to break, so this should be treated
+as experimental. Redlines are only generated if `pdf` is `"true"`. Further,
+if this path does not exist, a redline is simply not generated.
+
 ### `pdf`
 
-Generate a PDF from `markdown-file`. Default: `"true"`.
+Generate a PDF from `markdown_file`. Default: `"true"`.
 
 The resulting PDF will be in the same directory of `GITHUB_WORKSPACE` as the
 input file, but with a `pdf` extension.
@@ -56,12 +71,29 @@ Add a "DRAFT" watermark to the resulting document. Default: `"false"`
 
 This is currently only supported for PDF outputs.
 
+## Outputs
+
+### `pdf_file`
+
+The path to the generated PDF file, if `pdf` was `"true"`, relative to
+`GITHUB_WORKSPACE`.
+
+### `docx_file`
+
+The path to the generated DOCX file, if `docx` was `"true"`, relative to
+`GITHUB_WORKSPACE`.
+
+### `pdf_redline_file`
+
+The path to the generated PDF redline, if `pdf` was `"true"` and `diff_file`
+provided a path to a valid Markdown file.
+
 ## Example usage
 
 ```
 uses: cabforum/build-guidelines-action@v1
 with:
-  markdown-file: docs/BR.md
+  markdown_file: docs/BR.md
   draft: true
   lint: true
 ```

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ For example, on a `push` event, this would be the
 SHA-1's file (e.g. using [`actions/checkout`](https://github.com/actions/checkout)
 with a `ref` of `${{ github.event.push.before }}` and a custom `path`).
 
-This is fairly experimental and prone to break, so this should be treated
-as experimental. Redlines are only generated if `pdf` is `"true"`. Further,
-if this path does not exist, a redline is simply not generated.
+This is fairly experimental and prone to break. Redlines are only generated
+if `pdf` is `"true"`. Further, if this path does not exist, a redline is
+simply not generated.
 
 ### `pdf`
 

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ outputs:
   docx_file:
     description: 'The generated DOCX file (if docx was true), relative to GITHUB_WORKSPACE'
   pdf_redline_file:
-    description: 'The generated PDF redline file (if pdf was true and diff-file was supplied), relative to GITHUB_WORKSPACE'
+    description: 'The generated PDF redline file (if pdf was true and diff_file was supplied), relative to GITHUB_WORKSPACE'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,10 @@ inputs:
   markdown-file:
     description: 'Name of the file to convert'
     required: true
+  diff-file:
+    description: 'Previous version to diff against (EXPERIMENTAL)'
+    required: false
+    default: ''
   pdf:
     description: 'Generate a PDF file (true/false)'
     required: false
@@ -20,6 +24,13 @@ inputs:
     description: 'Include a draft watermark (PDF-only for now) (true/false)'
     required: false
     default: 'false'
+outputs:
+  pdf-file:
+    description: 'The generated PDF file (if pdf was true), relative to GITHUB_WORKSPACE'
+  docx-file:
+    description: 'The generated DOCX file (if docx was true), relative to GITHUB_WORKSPACE'
+  pdf-redline-file:
+    description: 'The generated PDF redline file (if pdf was true and diff-file was supplied), relative to GITHUB_WORKSPACE'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -1,10 +1,10 @@
 name: 'Build CA/Browser Forum Guideline'
 description: 'Convert a Pandoc-flavored Markdown file to PDF and DOCX using the CA/B Forum Guideline template'
 inputs:
-  markdown-file:
+  markdown_file:
     description: 'Name of the file to convert'
     required: true
-  diff-file:
+  diff_file:
     description: 'Previous version to diff against (EXPERIMENTAL)'
     required: false
     default: ''
@@ -25,14 +25,14 @@ inputs:
     required: false
     default: 'false'
 outputs:
-  pdf-file:
+  pdf_file:
     description: 'The generated PDF file (if pdf was true), relative to GITHUB_WORKSPACE'
-  docx-file:
+  docx_file:
     description: 'The generated DOCX file (if docx was true), relative to GITHUB_WORKSPACE'
-  pdf-redline-file:
+  pdf_redline_file:
     description: 'The generated PDF redline file (if pdf was true and diff-file was supplied), relative to GITHUB_WORKSPACE'
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
-    - ${{ inputs.markdown-file }}
+    - ${{ inputs.markdown_file }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,15 +26,11 @@ BASE_FILE="${1%.*}"
 
 DIFF_FILE=
 if [ ! -z "${INPUT_DIFF_FILE}" ]; then
-  if [ ! -f "${INPUT_DIFF_FILE}" ]; then
-    echo "Missing diff_file: ${INPUT_DIFF_FILE} cannot be found."
-    exit 2
+  if [ -f "${INPUT_DIFF_FILE}" ] && [ "${INPUT_DIFF_FILE##*.}" == "md" ]; then
+    DIFF_FILE="${INPUT_DIFF_FILE}"
+  else
+    echo "Skipping redline; unable to find ${INPUT_DIFF_FILE}"
   fi
-  if [ "${INPUT_DIFF_FILE##*.}" != "md" ]; then
-    echo "Invalid diff_file specified: ${INPUT_DIFF_FILE} is not a Markdown file."
-    exit 2
-  fi
-  DIFF_FILE="${INPUT_DIFF_FILE}"
 fi
 
 PANDOC_ARGS=( -f markdown --table-of-contents -s )

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,7 +27,7 @@ BASE_FILE="${1%.*}"
 DIFF_FILE=
 if [ ! -z "${INPUT_DIFF_FILE}" ]; then
   if [ ! -f "${INPUT_DIFF_FILE}" ]; then
-    echo "Missing diff_file: ${1} cannot be found."
+    echo "Missing diff_file: ${INPUT_DIFF_FILE} cannot be found."
     exit 2
   fi
   if [ "${INPUT_DIFF_FILE##*.}" != "md" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,7 @@ TEXINPUTS="${TEXINPUTS:-}"
 
 if [ "$#" -ne 1 ]; then
   echo "No markdown file specified"
-  echo "Usage: $0 <markdown-file.md>"
+  echo "Usage: $0 <markdown_file.md>"
   exit 1
 fi
 if [ ! -f "$1" ]; then
@@ -27,11 +27,11 @@ BASE_FILE="${1%.*}"
 DIFF_FILE=
 if [ ! -z "${INPUT_DIFF_FILE}" ]; then
   if [ ! -f "${INPUT_DIFF_FILE}" ]; then
-    echo "Missing diff-file: ${1} cannot be found."
+    echo "Missing diff_file: ${1} cannot be found."
     exit 2
   fi
   if [ "${INPUT_DIFF_FILE##*.}" != "md" ]; then
-    echo "Invalid diff-file specified: ${INPUT_DIFF_FILE} is not a Markdown file."
+    echo "Invalid diff_file specified: ${INPUT_DIFF_FILE} is not a Markdown file."
     exit 2
   fi
   DIFF_FILE="${INPUT_DIFF_FILE}"
@@ -56,7 +56,7 @@ if [ "$INPUT_PDF" = "true" ]; then
   pandoc "${PANDOC_ARGS[@]}" -t latex --template=/cabforum/templates/guideline.latex -o "${BASE_FILE}.tex" "${1}"
   TEXINPUTS="${TEXINPUTS}:/cabforum/" pandoc "${PANDOC_PDF_ARGS[@]}"
   set +x
-  echo "::set-output name=pdf-file::${BASE_FILE}.pdf"
+  echo "::set-output name=pdf_file::${BASE_FILE}.pdf"
   echo "::endgroup::"
 
   if [ ! -z "${DIFF_FILE}" ]; then
@@ -73,7 +73,7 @@ if [ "$INPUT_PDF" = "true" ]; then
     TEXINPUTS="${TEXINPUTS}:/cabforum/" xelatex -interaction=nonstopmode --output-directory="${TMP_DIR}" "${OUT_DIFF_TEX}-redline.tex"
     set +x
     cp "${OUT_DIFF_TEX}-redline.pdf" "${BASE_FILE}-redline.pdf"
-    echo "::set-output name=pdf-redline-file::${BASE_FILE}-redline.pdf"
+    echo "::set-output name=pdf_redline_file::${BASE_FILE}-redline.pdf"
     echo "::endgroup::"
   fi
 
@@ -89,7 +89,7 @@ if [ "$INPUT_DOCX" = "true" ]; then
   set -x
   pandoc "${PANDOC_DOCX_ARGS[@]}"
   set +x
-  echo "::set-output name=docx-file::${BASE_FILE}.docx"
+  echo "::set-output name=docx_file::${BASE_FILE}.docx"
   echo "::endgroup::"
 fi
 

--- a/templates/guideline.latex
+++ b/templates/guideline.latex
@@ -21,7 +21,8 @@
 \usepackage{graphicx}
 
 % Used by Pandoc tables
-\usepackage{longtable,booktabs}
+\usepackage{longtable,booktabs, array}
+\usepackage{calc}
 
 % Configure colors
 \usepackage{xcolor}


### PR DESCRIPTION
Attempt experimental redline support, using intermediate LaTeX files
generated from the Markdown, diffing those, and then attempting to
convert the resulting diff'd file into a PDF.

This does have some real sharp edges, and generates a ton of warnings
running XeTeX on the resulting diff, but helps provide a bit of a
rough estimate. For Ballots, it's likely that using a more formal
tool like Acrobat would be cleaner, using the PDFs to diff, or using
Word to compare the Word docs.

Tools like pandiff use the HTML output, but HTML output is currently
disabled.

In doing so, switch to using Action output files with explicit
filenames, just to allow easier migration of paths in the future.

This is a breaking change from previous versions, and thus should
get a new major version tag, as input parameters were renamed from
using hyphens to using underscores, in order to better play with
the Bash script.