### PR TITLE
Update Action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
           path: build-guidelines-action.tgz
   test_docker:
     name: Test Docker Image
-    runs-on: ubunutu-20.04
+    runs-on: ubuntu-20.04
     needs:
       - build_docker
     env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,8 +4,37 @@ jobs:
   build_docker:
     name: Build Docker Image
     runs-on: ubuntu-20.04
+    env:
+      DOCKER_TAG: cabforum/build-guidelines-action
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Build Image
-        run: docker build .
+        run: docker build --tag ${{ env.DOCKER_TAG}} .
+      - name: Save image
+        run: |
+          docker save ${{ env.DOCKER_TAG }} |\
+          gzip > build-guidelines-action.tgz
+      - name: Upload archive
+        uses: actions/upload-artifact@v1
+        with:
+          name: build-guidelines-action
+          path: build-guidelines-action.tgz
+  test_docker:
+    name: Test Docker Image
+    runs-on: ubunutu-20.04
+    needs:
+      - build_docker
+    env:
+      DOCKER_TAG: cabforum/build-guidelines-action
+    steps:
+      - name: Fetch Image
+        uses: actions/download-artifact@v1
+        with:
+          name: build-guidelines-action
+      - name: Load image
+        run: docker load --input build-guidelines-action/build-guidelines-action.tgz
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Test
+        run: make -C test test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,11 @@
+name: Build
+on: [push, pull_request]
+jobs:
+  build_docker:
+    name: Build Docker Image
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Build Image
+        run: docker build .

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
           docker save ${{ env.DOCKER_TAG }} |\
           gzip > build-guidelines-action.tgz
       - name: Upload archive
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: build-guidelines-action
           path: build-guidelines-action.tgz
@@ -29,9 +29,10 @@ jobs:
       DOCKER_TAG: cabforum/build-guidelines-action
     steps:
       - name: Fetch Image
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v2
         with:
           name: build-guidelines-action
+          path: build-guidelines-action
       - name: Load image
         run: docker load --input build-guidelines-action/build-guidelines-action.tgz
       - name: Checkout repository

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM pandoc/latex:2.11.2
+FROM pandoc/latex:2.11.3.2
+
+# Update tlmgr if necessary
+RUN tlmgr update --self
 
 # Install the necessary LaTeX packages
 RUN tlmgr install \
@@ -10,6 +13,7 @@ RUN tlmgr install \
   everypage \
   fancyhdr \
   latexdiff \
+  multirow \
   parskip \
   sourcecodepro \
   sourcesanspro \

--- a/templates/guideline.latex
+++ b/templates/guideline.latex
@@ -21,7 +21,7 @@
 \usepackage{graphicx}
 
 % Used by Pandoc tables
-\usepackage{longtable,booktabs, array}
+\usepackage{longtable,booktabs,array,multirow}
 \usepackage{calc}
 
 % Configure colors

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,55 @@
+ifndef DOCKER_TAG
+$(error DOCKER_TAG variable should contain the Docker tag being tested)
+endif
+
+makefile_path := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
+
+.PHONY: test
+test: test-broken-links test-good
+
+test-broken-links: broken-links.md
+	docker run --rm -v $(makefile_path):/data \
+			-e INPUT_LINT=true \
+			-e INPUT_PDF=false \
+			-e INPUT_DOCX=false \
+			$(DOCKER_TAG) \
+			/data/broken-links.md 2>&1 | diff -aurN expected/broken-links.out -
+
+.PHONY: test-good
+test-good: good.pdf good.docx good-redline.pdf
+
+# TODO(rsleevi): This isn't quite correct, because it presumes a particular
+# output path, which is not guaranteed by the Dockerfile, but instead
+# communicated as part of the action outputs.
+good.pdf: good.md
+	docker run --rm -v $(makefile_path):/data \
+		-e INPUT_LINT=false \
+		-e INPUT_PDF=true \
+		-e INPUT_DOCX=false \
+		-e INPUT_DRAFT=true \
+		$(DOCKER_TAG) \
+		/data/good.md
+
+good.docx: good.md
+	docker run --rm -v $(makefile_path):/data \
+		-e INPUT_LINT=false \
+		-e INPUT_PDF=false \
+		-e INPUT_DOCX=true \
+		$(DOCKER_TAG) \
+		/data/good.md
+
+good-redline.pdf: good.md good-diff.md
+	docker run --rm -v $(makefile_path):/data \
+		-e INPUT_LINT=false \
+		-e INPUT_PDF=true \
+		-e INPUT_DOCX=false \
+		-e INPUT_DRAFT=true \
+		-e INPUT_DIFF_FILE=/data/good-diff.md \
+		$(DOCKER_TAG) \
+		/data/good.md
+
+.PHONY: clean
+clean:
+	rm -rf *.pdf
+	rm -rf *.docx
+	rm -rf *.tex

--- a/test/broken-links.md
+++ b/test/broken-links.md
@@ -1,0 +1,21 @@
+---
+title: Broken Link Test
+subtitle: Version X
+author:
+  - CA/Browser Forum
+date: 7 January, 2021
+copyright: |
+  Copyright 2021 CA/Browser Forum
+
+  This work is licensed under the Creative Commons Attribution 4.0 International license.
+---
+
+# 1. SECTION ONE
+
+# 2. SECTION TWO
+
+# 2.1 Test
+
+This is a test of a [broken link](#section-four)
+
+# 3. SECTION THREE

--- a/test/expected/broken-links.out
+++ b/test/expected/broken-links.out
@@ -1,0 +1,5 @@
+::group::Checking links
++ pandoc -f markdown --table-of-contents -s -t gfm --lua-filter=/cabforum/filters/broken-links.lua -o /dev/null /data/broken-links.md
+::error::Unable to resolve link to section-four
+::endgroup::
++ set +x

--- a/test/good-diff.md
+++ b/test/good-diff.md
@@ -1,0 +1,53 @@
+---
+title: Good Test
+subtitle: Version X
+author:
+  - CA/Browser Forum
+date: 7 January, 2021
+copyright: |
+  Copyright 2021 CA/Browser Forum
+
+  This work is licensed under the Creative Commons Attribution 4.0 International license.
+---
+
+# 1. SECTION ONE
+
+# 2. SECTION TWO
+
+## 2.1 Test
+
+### 2.1.1 Another
+
+#### 2.1.1.1 Level
+
+1. This
+2. Is
+3. A
+4. List
+
+   a.  with
+   b.  subitems
+
+       i.  goes
+       ii.  several
+       iii.  levels
+       iv.  deep
+
+            A.  and
+            B.  demonstrates
+            C.  several
+            D.  list
+
+                1. styles
+                2. and
+
+                   a.  spacing
+                   b.  styles
+
+# SECTION THREE
+
+This is a link to [Section 2.1.1](#another).
+
+# SECTION FOUR
+
+This is a new section to test a diff.

--- a/test/good.md
+++ b/test/good.md
@@ -1,0 +1,49 @@
+---
+title: Good Test
+subtitle: Version X
+author:
+  - CA/Browser Forum
+date: 7 January, 2021
+copyright: |
+  Copyright 2021 CA/Browser Forum
+
+  This work is licensed under the Creative Commons Attribution 4.0 International license.
+---
+
+# 1. SECTION ONE
+
+# 2. SECTION TWO
+
+## 2.1 Test
+
+### 2.1.1 Another
+
+#### 2.1.1.1 Level
+
+1. This
+2. Is
+3. A
+4. List
+
+   a.  with
+   b.  subitems
+   c.  that
+
+       i.  goes
+       ii.  several
+       iii.  levels
+       iv.  deep
+
+            A.  and
+            B.  uses
+            C.  several
+            D.  list
+
+                1. styles
+                2. and
+
+                   a.  spacing
+
+# SECTION THREE
+
+This is a link to [Section 2.1.1](#another).


### PR DESCRIPTION
The action is currently failing because it's built on demand (i.e. not published to [Docker Hub or GitHub Packages](https://docs.github.com/en/free-pro-team@latest/actions/guides/publishing-docker-images)), and so it is built on demand.

The current Pandoc base image being used by the [2.0.0-rc1](https://github.com/cabforum/build-guidelines-action/releases/tag/v2.0.0-rc1) has an older `tlmgr`, and as a result, the initial image building step fails due to needing to update `tlmgr`.

This adds a step to explicitly update `tlmgr` as part of building the image. However, it also updates the base Pandoc image further than 2.0-RC (which also/alternatively resolves this issue), in order to take advantage of the Latex writer now supporting multi-column/multi-row tables.

In order to make sure such changes are safe in the future, it also introduces a base set of unit tests that build a PDF, a DOCX, a PDF redline, and lints for broken links, testing the core functionality of the action, and wires them up to GitHub Actions.