### PR TITLE
Change headings to GitHub style headings

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -33,7 +33,7 @@ if [ -n "${INPUT_DIFF_FILE}" ]; then
   fi
 fi
 
-PANDOC_ARGS=( -f markdown --table-of-contents -s )
+PANDOC_ARGS=( -f markdown+gfm_auto_identifiers --table-of-contents -s )
 
 if [ "$INPUT_DRAFT" = "true" ]; then
   echo "Draft detected. Adding draft watermark"

--- a/filters/broken-links.lua
+++ b/filters/broken-links.lua
@@ -9,6 +9,7 @@
 -- https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-error-message
 --]]
 local identifiers = {}
+local had_error = false
 
 function Block (b)
   if b.identifier then
@@ -26,10 +27,26 @@ function Link (l)
   local anchor = l.target:match('#(.*)')
   if anchor and not identifiers[anchor] then
     io.stdout:write("::error::Unable to resolve link to " .. anchor .. "\n")
+    had_error = true
+  end
+end
+
+function Pandoc (doc)
+  if had_error then
+    local ids = {}
+    for id,unused in pairs(identifiers) do
+      table.insert(ids, id)
+    end
+    io.stdout:write("Valid identifiers are:\n")
+    table.sort(ids)
+    for i,v in ipairs(ids) do
+      io.stdout:write(v .. "\n")
+    end
   end
 end
 
 return {
   {Block = Block, Inline = Inline},
-  {Link = Link}
+  {Link = Link},
+  {Pandoc = Pandoc}
 }

--- a/test/broken-links.md
+++ b/test/broken-links.md
@@ -19,3 +19,5 @@ copyright: |
 This is a test of a [broken link](#section-four)
 
 # 3. SECTION THREE
+
+This is a test of a [good link](#3-section-three)

--- a/test/expected/broken-links.out
+++ b/test/expected/broken-links.out
@@ -1,5 +1,11 @@
 ::group::Checking links
-+ pandoc -f markdown --table-of-contents -s -t gfm --lua-filter=/cabforum/filters/broken-links.lua -o /dev/null /data/broken-links.md
++ pandoc -f markdown+gfm_auto_identifiers --table-of-contents -s -t gfm --lua-filter=/cabforum/filters/broken-links.lua -o /dev/null /data/broken-links.md
 ::error::Unable to resolve link to section-four
+Valid identifiers are:
+
+1-section-one
+2-section-two
+21-test
+3-section-three
 + set +x
 ::endgroup::


### PR DESCRIPTION
Pandoc's default style for headings, as documented at
https://pandoc.org/MANUAL.html#headings-and-sections , is to remove
leading numbers from headings. This strips out leading section
identifiers (e.g. #foo instead of #1-foo). Pandoc does this to be
compatible with HTML 4.

This changes the Markdown reader to use the GitHub style of
creating section headers, which covers spaces to dashes, lowercases
everything, and removes punctuation other than - and _. Importantly,
this preserves numbers: "11.1.1 Foo" becomes "#11111-foo" instead of
just "#foo".

This makes it much easier to understand why a link was bad, and so
the Link checking filter is also updated to dump all the valid
identifiers whenever there is a broken link, which hopefully makes
it easier to correct the link in the event of a typo.