### PR TITLE
Properly handle fragment identifiers to other docs

### DIFF
--- a/filters/broken-links.lua
+++ b/filters/broken-links.lua
@@ -24,7 +24,7 @@ function Inline (i)
 end
 
 function Link (l)
-  local anchor = l.target:match('#(.*)')
+  local anchor = l.target:match('^#(.*)')
   if anchor and not identifiers[anchor] then
     io.stdout:write("::error::Unable to resolve link to " .. anchor .. "\n")
     had_error = true

--- a/test/broken-links.md
+++ b/test/broken-links.md
@@ -21,3 +21,8 @@ This is a test of a [broken link](#section-four)
 # 3. SECTION THREE
 
 This is a test of a [good link](#3-section-three)
+
+# 4. SECTION FOUR
+
+This is a test of an [external link](https://tools.ietf.org/html/rfc5280#section-4.1)
+that has a fragment identifier, but to another resource.

--- a/test/expected/broken-links.out
+++ b/test/expected/broken-links.out
@@ -7,4 +7,5 @@ Valid identifiers are:
 2-section-two
 21-test
 3-section-three
+4-section-four
 ::endgroup::


### PR DESCRIPTION
The regular expression used to test for broken links was
incorrectly testing for any fragment identifier, rather than
fragment identifiers within the current document. This fixes
it so that links to other documents, such as
https://tools.ietf.org/html/rfc5280#section-4.1 , don't
trigger warnings incorrectly.

Fixes https://github.com/cabforum/build-guidelines-action/issues/6