### PR TITLE
Add --no-highlight to the Pandoc arguments

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,7 +49,7 @@ if [ -n "${INPUT_DIFF_FILE}" ]; then
   fi
 fi
 
-PANDOC_ARGS=( -f markdown+gfm_auto_identifiers --table-of-contents -s )
+PANDOC_ARGS=( -f markdown+gfm_auto_identifiers --table-of-contents -s --no-highlight )
 
 if [ "$INPUT_DRAFT" = "true" ]; then
   echo "Draft detected. Adding draft watermark"

--- a/test/expected/broken-links.out
+++ b/test/expected/broken-links.out
@@ -1,5 +1,5 @@
 ::group::Checking links
-pandoc -f markdown+gfm_auto_identifiers --table-of-contents -s -t gfm --lua-filter=/cabforum/filters/broken-links.lua -o /dev/null /data/broken-links.md
+pandoc -f markdown+gfm_auto_identifiers --table-of-contents -s --no-highlight -t gfm --lua-filter=/cabforum/filters/broken-links.lua -o /dev/null /data/broken-links.md
 ::error::Unable to resolve link to section-four
 Valid identifiers are:
 

--- a/test/good.md
+++ b/test/good.md
@@ -47,3 +47,20 @@ copyright: |
 # SECTION THREE
 
 This is a link to [Section 2.1.1](#another).
+
+# SECTION FOUR
+
+This tests syntax highlighting.
+
+```asn1
+HumorValue ::= ENUMERATED {
+    Highly      (0),
+    Moderately  (1),
+    ...
+}
+
+Example ::= SEQUENCE {
+    Useful    BOOLEAN DEFAULT FALSE,
+    Amusing   HumorValue
+}
+```

--- a/test/good.md
+++ b/test/good.md
@@ -50,7 +50,7 @@ This is a link to [Section 2.1.1](#another).
 
 # SECTION FOUR
 
-This tests syntax highlighting.
+This tests syntax highlighting (namely, that nothing gets highlighted, but also nothing breaks).
 
 ```asn1
 HumorValue ::= ENUMERATED {


### PR DESCRIPTION
Pandoc supports syntax highlighting for code blocks that
explicitly specify a language. When used, it injects a
series of LaTeX macros into the template, which it then
uses as part of the conversion.

These macros weren't included when originally building
the template, meaning that attempting to specify a
language would cause a PDF conversion issue, due to
undefined LaTeX macros. While these can be added, the
color styles require further customization to fit within
the document look-and-feel. These can be customized with
JSON files using --highlight-style and, if necessary,
--syntax-definition for KDE XML syntax definition files.

Rather than work to customize the style and syntax
appropriate for the examples, for now, just disable
syntax highlighting. This can be revisited later, with
thematically-appropriate colors and robust language
support.

Fixes https://github.com/cabforum/build-guidelines-action/issues/7