### PR TITLE
Pin the TeX Live version to 2020

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM pandoc/latex:2.11.3.2
 
 # Update tlmgr if necessary
+RUN tlmgr option repository ftp://tug.org/historic/systems/texlive/2020/tlnet-final
 RUN tlmgr update --self
 
 # Install the necessary LaTeX packages


### PR DESCRIPTION
Until we get GitHub Containers setup, we end up building the Docker
image on every run, which means that the action depends on external
servers and services (unfortunately). TeX Live has updated to 2021,
which means that the current image base is out of date.

Updating Pandoc should also resolve this (by virtue of updating the
version of TeX Live in the base image, which we inherit from the
Pandoc base image), but in the interim, pin the version of TeX
Live to the 2020 repository to reflect what we're doing.

Fixes #20