### PR TITLE
Add support for publishing to GitHub Container Registry

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,12 +5,12 @@ jobs:
     name: Build Docker Image
     runs-on: ubuntu-20.04
     env:
-      DOCKER_TAG: cabforum/build-guidelines-action
+      DOCKER_TAG: build-guidelines-action
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Build Image
-        run: docker build --tag ${{ env.DOCKER_TAG}} .
+        run: docker build . --file Dockerfile --tag ${{ env.DOCKER_TAG}} --label "runnumber=${GITHUB_RUN_ID}"
       - name: Save image
         run: |
           docker save ${{ env.DOCKER_TAG }} |\
@@ -20,13 +20,14 @@ jobs:
         with:
           name: build-guidelines-action
           path: build-guidelines-action.tgz
+
   test_docker:
     name: Test Docker Image
     runs-on: ubuntu-20.04
     needs:
       - build_docker
     env:
-      DOCKER_TAG: cabforum/build-guidelines-action
+      DOCKER_TAG: build-guidelines-action
     steps:
       - name: Fetch Image
         uses: actions/download-artifact@v2
@@ -39,3 +40,41 @@ jobs:
         uses: actions/checkout@v2
       - name: Test
         run: make -C test test
+
+  publish:
+    if: ${{ github.event_name != 'pull_request' }}
+    name: Publish (Push only)
+    runs-on: ubuntu-20.04
+    needs:
+      - test_docker
+    env:
+      DOCKER_TAG: build-guidelines-action
+    steps:
+      - name: Fetch Image
+        uses: actions/download-artifact@v2
+        with:
+          name: build-guidelines-action
+          path: build-guidelines-action
+      - name: Load image
+        run: docker load --input build-guidelines-action/build-guidelines-action.tgz
+      - name: Log into registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Push image
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$DOCKER_TAG
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          # Use Docker 'latest' tag convention
+          [ "$VERSION" == "main" ] && VERSION=latest
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+          docker tag $DOCKER_TAG $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION
+          if [ "${{ github.event_name }}" = "push" ]; then
+            docker tag $IMAGE_ID:$VERSION $IMAGE_ID:sha-${GITHUB_SHA::8}
+            docker push $IMAGE_ID:sha-${GITHUB_SHA::8}
+          fi

--- a/action.yml
+++ b/action.yml
@@ -34,5 +34,3 @@ outputs:
 runs:
   using: 'docker'
   image: 'Dockerfile'
-  args:
-    - ${{ inputs.markdown_file }}

--- a/test/Makefile
+++ b/test/Makefile
@@ -21,8 +21,9 @@ test-broken-links: broken-links.md
 			-e INPUT_LINT=true \
 			-e INPUT_PDF=false \
 			-e INPUT_DOCX=false \
+			-e INPUT_MARKDOWN_FILE=/data/broken-links.md \
 			$(DOCKER_TAG) \
-			/data/broken-links.md &> $(TMP)/broken-links-actual.out
+			&> $(TMP)/broken-links-actual.out
 	diff -aurN expected/broken-links.out $(TMP)/broken-links-actual.out
 	@echo "::$(stop_token)::"
 	@echo "::endgroup::"
@@ -41,8 +42,8 @@ good.pdf: good.md
 		-e INPUT_PDF=true \
 		-e INPUT_DOCX=false \
 		-e INPUT_DRAFT=true \
-		$(DOCKER_TAG) \
-		/data/good.md
+		-e INPUT_MARKDOWN_FILE=/data/good.md \
+		$(DOCKER_TAG)
 	@echo "::$(stop_token)::"
 	@echo "::endgroup::"
 
@@ -53,8 +54,8 @@ good.docx: good.md
 		-e INPUT_LINT=false \
 		-e INPUT_PDF=false \
 		-e INPUT_DOCX=true \
-		$(DOCKER_TAG) \
-		/data/good.md
+		-e INPUT_MARKDOWN_FILE=/data/good.md \
+		$(DOCKER_TAG)
 	@echo "::$(stop_token)::"
 	@echo "::endgroup::"
 
@@ -67,8 +68,8 @@ good-redline.pdf: good.md good-diff.md
 		-e INPUT_DOCX=false \
 		-e INPUT_DRAFT=true \
 		-e INPUT_DIFF_FILE=/data/good-diff.md \
-		$(DOCKER_TAG) \
-		/data/good.md
+		-e INPUT_MARKDOWN_FILE=/data/good.md \
+		$(DOCKER_TAG)
 	@echo "::$(stop_token)::"
 	@echo "::endgroup::"
 


### PR DESCRIPTION
This addresses issues like #20 by publishing the built docker image, rather than requiring the workflow to build the Dockerfile for every run.

For pushes (and pushes only), this will publish an image at `docker://ghcr.io/cabforum/build-guidelines-action`, then tagged with either/and the SHA-1 (full hash), the SHA-1 (abbreviated hash), and the branch name, and for `main`, `:latest`

For example, a push to `refs/heads/branch` would result in `build-guidelines-action:branch` and `build-guidelines-action:sha-(sha-1-abbreviated)`, while to `refs/heads/main` would result in `build-guidelines-action:latest`, and `build-gudelines-action:sha-(sha-1)`.

Similarly, a push of a tag with a 'v' prefix (e.g. `v2.0`) will result in the same tag, without the `v`: `build-guidelines-action:2.0`.

The `uses` syntax would change from:
```
  - uses: cabforum/build-guidelines-action@v2.0
```
to
```
  - uses: docker://ghcr.io/cabforum/build-guidelines-action:2.0
 ```