### PR TITLE
Export version and include in filename

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,7 @@ jobs:
       DOCKER_TAG: build-guidelines-action
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build Image
         run: docker build . --file Dockerfile --tag ${{ env.DOCKER_TAG}} --label "runnumber=${GITHUB_RUN_ID}"
       - name: Save image
@@ -16,7 +16,7 @@ jobs:
           docker save ${{ env.DOCKER_TAG }} |\
           gzip > build-guidelines-action.tgz
       - name: Upload archive
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-guidelines-action
           path: build-guidelines-action.tgz
@@ -30,14 +30,16 @@ jobs:
       DOCKER_TAG: build-guidelines-action
     steps:
       - name: Fetch Image
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-guidelines-action
           path: build-guidelines-action
       - name: Load image
         run: docker load --input build-guidelines-action/build-guidelines-action.tgz
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Test
         run: make -C test test
 
@@ -51,7 +53,7 @@ jobs:
       DOCKER_TAG: build-guidelines-action
     steps:
       - name: Fetch Image
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-guidelines-action
           path: build-guidelines-action

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ RUN tlmgr install \
   tocloft \
   xecjk
 
-# Install bash
-RUN apk add --no-cache bash coreutils
+# Install bash, coreutils and git
+RUN apk add --no-cache bash coreutils git
 
 # Install NotoSerif fonts
 RUN mkdir -p /tmp/fonts && \

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CA/Browser Forum Guidline builder action
+# CA/Browser Forum Guideline builder action
 
 This action customizes the [Pandoc dockerfiles](https://github.com/pandoc/dockerfiles)
 for use by [CA/Browser Forum](https://www.cabforum.org) Chartered Working
@@ -87,6 +87,26 @@ The path to the generated DOCX file, if `docx` was `"true"`, relative to
 
 The path to the generated PDF redline, if `pdf` was `"true"` and `diff_file`
 provided a path to a valid Markdown file.
+
+### `file_version`
+
+The version of the file, as extracted from the subtitle of the document.
+
+### `file_commit`
+
+The short commit hash of the file.
+
+### `diff_version`
+
+The version of the diff file, as extracted from the subtitle of the document.
+
+### `diff_commit`
+
+The short commit hash of the diff file.
+
+### `changelog`
+
+A list of commit messages from `diff_commit` to `file_commit`.
 
 ## Example usage
 

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,12 @@ outputs:
     description: 'The generated DOCX file (if docx was true), relative to GITHUB_WORKSPACE'
   pdf_redline_file:
     description: 'The generated PDF redline file (if pdf was true and diff_file was supplied), relative to GITHUB_WORKSPACE'
+  file_version:
+    description: 'The version of the file, as extracted from the subtitle of the document'
+  diff_version:
+    description: 'The version of the diff file, as extracted from the subtitle of the document'
+  changelog:
+    description: 'A list of commit messages from diff commit to file commit.'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/test/Makefile
+++ b/test/Makefile
@@ -4,9 +4,10 @@ endif
 
 SHELL = /bin/bash
 
-makefile_path := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 TMP := $(shell mktemp -d)
 GITHUB_OUTPUT ?= /dev/null
+GITHUB_SHA ?= $(shell git rev-parse HEAD)
+REPOSITORY = $(shell git rev-parse --show-toplevel)
 
 # Generate a random token per invocation that can be used to disable/enable
 # GitHub command processing.
@@ -18,14 +19,14 @@ test: test-broken-links test-good
 test-broken-links: broken-links.md
 	@echo "::group::$@"
 	@echo "::stop-commands::$(stop_token)"
-	docker run --rm -v $(makefile_path):/data \
+	docker run --rm -v $(REPOSITORY):/data \
 			-e INPUT_LINT=true \
 			-e INPUT_PDF=false \
 			-e INPUT_DOCX=false \
-			-e INPUT_MARKDOWN_FILE=/data/broken-links.md \
-			-e GITHUB_OUTPUT=$GITHUB_OUTPUT \
+			-e INPUT_MARKDOWN_FILE=/data/test/broken-links.md \
+			-v $(GITHUB_OUTPUT):$(GITHUB_OUTPUT) -e GITHUB_OUTPUT=${GITHUB_OUTPUT} \
 			$(DOCKER_TAG) \
-			&> $(TMP)/broken-links-actual.out
+			2>&1 | tee $(TMP)/broken-links-actual.out
 	diff -aurN expected/broken-links.out $(TMP)/broken-links-actual.out
 	@echo "::$(stop_token)::"
 	@echo "::endgroup::"
@@ -39,13 +40,14 @@ test-good: good.pdf good.docx good-redline.pdf
 good.pdf: good.md
 	@echo "::group::$@"
 	@echo "::stop-commands::$(stop_token)"
-	docker run --rm -v $(makefile_path):/data \
+	ls -lah
+	docker run --rm -v $(REPOSITORY):/data \
 		-e INPUT_LINT=false \
 		-e INPUT_PDF=true \
 		-e INPUT_DOCX=false \
 		-e INPUT_DRAFT=true \
-		-e INPUT_MARKDOWN_FILE=/data/good.md \
-		-e GITHUB_OUTPUT=$GITHUB_OUTPUT \
+		-e INPUT_MARKDOWN_FILE=/data/test/good.md \
+		-v $(GITHUB_OUTPUT):$(GITHUB_OUTPUT) -e GITHUB_OUTPUT=${GITHUB_OUTPUT} \
 		$(DOCKER_TAG)
 	@echo "::$(stop_token)::"
 	@echo "::endgroup::"
@@ -53,12 +55,12 @@ good.pdf: good.md
 good.docx: good.md
 	@echo "::group::$@"
 	@echo "::stop-commands::$(stop_token)"
-	docker run --rm -v $(makefile_path):/data \
+	docker run --rm -v $(REPOSITORY):/data \
 		-e INPUT_LINT=false \
 		-e INPUT_PDF=false \
 		-e INPUT_DOCX=true \
-		-e INPUT_MARKDOWN_FILE=/data/good.md \
-		-e GITHUB_OUTPUT=$GITHUB_OUTPUT \
+		-e INPUT_MARKDOWN_FILE=/data/test/good.md \
+		-v $(GITHUB_OUTPUT):$(GITHUB_OUTPUT) -e GITHUB_OUTPUT=${GITHUB_OUTPUT} \
 		$(DOCKER_TAG)
 	@echo "::$(stop_token)::"
 	@echo "::endgroup::"
@@ -66,14 +68,14 @@ good.docx: good.md
 good-redline.pdf: good.md good-diff.md
 	@echo "::group::$@"
 	@echo "::stop-commands::$(stop_token)"
-	docker run --rm -v $(makefile_path):/data \
+	docker run --rm -v $(REPOSITORY):/data \
 		-e INPUT_LINT=false \
 		-e INPUT_PDF=true \
 		-e INPUT_DOCX=false \
 		-e INPUT_DRAFT=true \
-		-e INPUT_DIFF_FILE=/data/good-diff.md \
-		-e INPUT_MARKDOWN_FILE=/data/good.md \
-		-e GITHUB_OUTPUT=$GITHUB_OUTPUT \
+		-e INPUT_DIFF_FILE=/data/test/good-diff.md \
+		-e INPUT_MARKDOWN_FILE=/data/test/good.md \
+		-v $(GITHUB_OUTPUT):$(GITHUB_OUTPUT) -e GITHUB_OUTPUT=${GITHUB_OUTPUT} \
 		$(DOCKER_TAG)
 	@echo "::$(stop_token)::"
 	@echo "::endgroup::"

--- a/test/Makefile
+++ b/test/Makefile
@@ -61,7 +61,8 @@ good.docx: good.md
 		-e INPUT_PDF=false \
 		-e INPUT_DOCX=true \
 		-e INPUT_MARKDOWN_FILE=/data/test/good.md \
-		-v $(GITHUB_OUTPUT):$(GITHUB_OUTPUT) -e GITHUB_OUTPUT=${GITHUB_OUTPUT} \
+		-e GITHUB_OUTPUT=${GITHUB_OUTPUT} \
+		-v $(GITHUB_OUTPUT):$(GITHUB_OUTPUT) \
 		$(DOCKER_TAG)
 	@echo "::$(stop_token)::"
 	@echo "::endgroup::"
@@ -76,7 +77,8 @@ good-redline.pdf: good.md good-diff.md
 		-e INPUT_DRAFT=true \
 		-e INPUT_DIFF_FILE=/data/test/good-diff.md \
 		-e INPUT_MARKDOWN_FILE=/data/test/good.md \
-		-v $(GITHUB_OUTPUT):$(GITHUB_OUTPUT) -e GITHUB_OUTPUT=${GITHUB_OUTPUT} \
+		-e GITHUB_OUTPUT=${GITHUB_OUTPUT} \
+		-v $(GITHUB_OUTPUT):$(GITHUB_OUTPUT) \
 		$(DOCKER_TAG)
 	@echo "::$(stop_token)::"
 	@echo "::endgroup::"

--- a/test/Makefile
+++ b/test/Makefile
@@ -47,7 +47,8 @@ good.pdf: good.md
 		-e INPUT_DOCX=false \
 		-e INPUT_DRAFT=true \
 		-e INPUT_MARKDOWN_FILE=/data/test/good.md \
-		-v $(GITHUB_OUTPUT):$(GITHUB_OUTPUT) -e GITHUB_OUTPUT=${GITHUB_OUTPUT} \
+		-e GITHUB_OUTPUT=${GITHUB_OUTPUT} \
+		-v $(GITHUB_OUTPUT):$(GITHUB_OUTPUT) \
 		$(DOCKER_TAG)
 	@echo "::$(stop_token)::"
 	@echo "::endgroup::"

--- a/test/expected/broken-links.out
+++ b/test/expected/broken-links.out
@@ -1,5 +1,8 @@
+::group::Extract version
+File broken-links.md is at version vX and commit 60e44c6
+::endgroup::
 ::group::Checking links
-pandoc -f markdown+gfm_auto_identifiers --table-of-contents -s --no-highlight --lua-filter=/cabforum/filters/pandoc-list-table.lua --filter=/usr/bin/pantable -t gfm --lua-filter=/cabforum/filters/broken-links.lua -o /dev/null /data/broken-links.md
+pandoc -f markdown+gfm_auto_identifiers --table-of-contents -s --no-highlight --lua-filter=/cabforum/filters/pandoc-list-table.lua --filter=/usr/bin/pantable -t gfm --lua-filter=/cabforum/filters/broken-links.lua -o /dev/null /data/test/broken-links.md
 ::error::Unable to resolve link to section-four
 Valid identifiers are:
 


### PR DESCRIPTION
This PR adds additional information to the action output so that we do not have to specify this for each repository action individually.

At the same time it included the document version in the filenames (plus this short commit hash for draft documents) so that it becomes easier to identify downloads and that we can attach the documents directly to a GitHub release.

The changelog filters down to only include the changes for the specific document, ignoring changes to other documents or files in the repository. 

In many cases there are no changes as we are only looking back to the latest commit in the target branch, but the PR is likely for a specific document. This generally means that the other documents do not need a new release or build as they have not changed. I will likely handle this by checking for which files have changed and only include those in the build matrix. At the same time we can check if the commits/versions have changed or not.