### PR TITLE
Lint Markdown using `mdl` to enforce correct presentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,10 @@ RUN apk add --update --no-cache python3 py3-pip py3-numpy
 RUN python3 -m pip install pyyaml==5.3.1
 RUN python3 -m pip install pantable==0.13.4
 
+# Install Markdown lint tool
+RUN apk add ruby-full
+RUN gem install mdl
+
 RUN mkdir -p /cabforum
 RUN mkdir -p /cabforum/templates
 RUN mkdir -p /cabforum/filters

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -140,7 +140,15 @@ if [ "$INPUT_DOCX" = "true" ]; then
   echo "::endgroup::"
 fi
 
+# TODO evaluate to move this entire linting block before any document generation.
 if [ "$INPUT_LINT" = "true" ]; then
+  echo "::group::Linting Markdown"
+  # Enabled checks:
+  # - MD032, https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md032---lists-should-be-surrounded-by-blank-lines
+  # TODO evaluate to allow to override the list of checks.
+  LogAndRun mdl -r MD032 "${INPUT_MARKDOWN_FILE}"
+  echo "::endgroup::"
+
   echo "::group::Checking links"
   PANDOC_LINT_ARGS=( "${PANDOC_ARGS[@]}" )
   PANDOC_LINT_ARGS+=( -t gfm )

--- a/test/broken-links.md
+++ b/test/broken-links.md
@@ -2,7 +2,9 @@
 title: Broken Link Test
 subtitle: Version X
 author:
+
   - CA/Browser Forum
+
 date: 7 January, 2021
 copyright: |
   Copyright 2021 CA/Browser Forum

--- a/test/expected/broken-links.out
+++ b/test/expected/broken-links.out
@@ -1,5 +1,8 @@
 ::group::Extract version
-File broken-links.md is at version vX and commit 60e44c6
+File broken-links.md is at version vX and commit 09f9e32
+::endgroup::
+::group::Linting Markdown
+mdl -r MD032 /data/test/broken-links.md
 ::endgroup::
 ::group::Checking links
 pandoc -f markdown+gfm_auto_identifiers --table-of-contents -s --no-highlight --lua-filter=/cabforum/filters/pandoc-list-table.lua --filter=/usr/bin/pantable -t gfm --lua-filter=/cabforum/filters/broken-links.lua -o /dev/null /data/test/broken-links.md

--- a/test/good-diff.md
+++ b/test/good-diff.md
@@ -2,7 +2,9 @@
 title: Good Test
 subtitle: Version X
 author:
+
   - CA/Browser Forum
+
 date: 7 January, 2021
 copyright: |
   Copyright 2021 CA/Browser Forum

--- a/test/good.md
+++ b/test/good.md
@@ -2,7 +2,9 @@
 title: Good Test
 subtitle: Version X
 author:
+
   - CA/Browser Forum
+
 date: 7 January, 2021
 copyright: |
   Copyright 2021 CA/Browser Forum


### PR DESCRIPTION
Currently there are some Markdown format issues in CA/B Forum documents like https://github.com/cabforum/servercert/blob/main/docs/BR.md. 

For example the following Markdown excerpt from the TLS BRs:

```
### 4.9.7 CRL issuance frequency

CRLs must be available via a publicly-accessible HTTP URL (i.e., "published").

Within twenty-four (24) hours of issuing its first Certificate, the CA MUST generate and publish either:
- a full and complete CRL; OR
- partitioned (i.e., "sharded") CRLs that, when aggregated, represent the equivalent of a full and complete CRL.

CAs issuing Subscriber Certificates:  
1. MUST update and publish a new CRL at least every: 
     - seven (7) days if all Certificates include an Authority Information Access extension with an id-ad-ocsp accessMethod (“AIA OCSP pointer”); or
     - four (4) days in all other cases; 
2. MUST update and publish a new CRL within twenty-four (24) hours after recording a Certificate as revoked.

CAs issuing CA Certificates:  
1. MUST update and publish a new CRL at least every twelve (12) months;
2. MUST update and publish a new CRL within twenty-four (24) hours after recording a Certificate as revoked.

CAs MUST continue issuing CRLs until one of the following is true:
- all Subordinate CA Certificates containing the same Subject Public Key are expired or revoked; OR
- the corresponding Subordinate CA Private Key is destroyed.
```

Looks like this when converted into PDF:

<img width="591" alt="brs_screenshot_before" src="https://github.com/cabforum/build-guidelines-action/assets/230942/888c1c7b-bfac-4db6-84f2-406753eb9f5a">

Where you can see that lists are not rendered correctly. 

Now, with the following corrected Markdown (see the extra blank lines around lists): 

```
### 4.9.7 CRL issuance frequency

CRLs must be available via a publicly-accessible HTTP URL (i.e., "published").

Within twenty-four (24) hours of issuing its first Certificate, the CA MUST generate and publish either:

- a full and complete CRL; OR
- partitioned (i.e., "sharded") CRLs that, when aggregated, represent the equivalent of a full and complete CRL.

CAs issuing Subscriber Certificates:

1. MUST update and publish a new CRL at least every: 
     - seven (7) days if all Certificates include an Authority Information Access extension with an id-ad-ocsp accessMethod (“AIA OCSP pointer”); or
     - four (4) days in all other cases; 
2. MUST update and publish a new CRL within twenty-four (24) hours after recording a Certificate as revoked.

CAs issuing CA Certificates:

1. MUST update and publish a new CRL at least every twelve (12) months;
2. MUST update and publish a new CRL within twenty-four (24) hours after recording a Certificate as revoked.

CAs MUST continue issuing CRLs until one of the following is true:

- all Subordinate CA Certificates containing the same Subject Public Key are expired or revoked; OR
- the corresponding Subordinate CA Private Key is destroyed.
```

It would look like this:

<img width="591" alt="brs_screenshot_after" src="https://github.com/cabforum/build-guidelines-action/assets/230942/da81c20c-4aa6-4e38-b1a3-348c28064177">

This PR looks to enforce this correct Markdown style by introducing the usage of https://github.com/markdownlint/markdownlint/ during the workflow run. 

Other Markdown linting rules (see https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md) could be enforced in the future or they could be passed as parameters to the Action.